### PR TITLE
Fix: by enabling ACL (OBJECT_WRITER) on CloudfrontLoggingBucket

### DIFF
--- a/lib/wild-rydes-app-stack.ts
+++ b/lib/wild-rydes-app-stack.ts
@@ -12,7 +12,7 @@
  */
 
 import { Construct } from "constructs";
-import { Stack, StackProps, Duration, CfnOutput, Aws, CustomResource, RemovalPolicy } from 'aws-cdk-lib';
+import { Stack, StackProps, Duration, CfnOutput, Aws, CustomResource, RemovalPolicy, aws_s3 } from 'aws-cdk-lib';
 import { CloudFrontToS3 } from '@aws-solutions-constructs/aws-cloudfront-s3';
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import {  Provider } from 'aws-cdk-lib/custom-resources';
@@ -34,6 +34,9 @@ export class WildRydesAppStack extends Stack {
         removalPolicy: RemovalPolicy.DESTROY,
         autoDeleteObjects: true,
         versioned: false
+      },
+      cloudFrontLoggingBucketProps:{
+        objectOwnership: aws_s3.ObjectOwnership.OBJECT_WRITER
       },
       logS3AccessLogs: false
     });


### PR DESCRIPTION
Since beginning of April 2023 all newly created S3 buckets are set to a disabled ACL per default. For  CloudFront logging buckets, the ACL must be enabled (otherwise deployment fails). The bug was fixed through overwriting the default objectOwnership for the CloudFront logging bucket. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
